### PR TITLE
Fix: Aimbot Simplified logic

### DIFF
--- a/src/game/features/self/Aimbot.cpp
+++ b/src/game/features/self/Aimbot.cpp
@@ -1,26 +1,50 @@
 #include "core/commands/BoolCommand.hpp"
+#include "core/commands/LoopedCommand.hpp"
+#include "game/backend/Self.hpp"
+#include "game/gta/Natives.hpp"
+#include "game/gta/Pools.hpp"
 #include "game/pointers/Pointers.hpp"
+
+#include <set>
 
 namespace YimMenu::Features
 {
-	class Aimbot : public BoolCommand
+	class Aimbot : public LoopedCommand
 	{
-		using BoolCommand::BoolCommand;
+		using LoopedCommand::LoopedCommand;
+
+		std::set<int> killed_peds;
 
 		virtual void OnEnable() override
 		{
 			Pointers.ShouldNotTargetEntityPatch->Apply();
 			Pointers.GetAssistedAimTypePatch->Apply();
+			killed_peds.clear();
+		}
+
+		virtual void OnTick() override
+		{
+			for (Ped ped : Pools::GetPeds())
+			{
+				int handle = ped.GetHandle();
+				if (!killed_peds.contains(handle) && !ped.IsPlayer() && ped.IsDead()
+				    && ENTITY::HAS_ENTITY_BEEN_DAMAGED_BY_ENTITY(handle, Self::GetPed().GetHandle(), false))
+				{
+					killed_peds.insert(handle);
+					PAD::DISABLE_CONTROL_ACTION(0, 25, true);
+				}
+			}
 		}
 
 		virtual void OnDisable() override
 		{
 			Pointers.ShouldNotTargetEntityPatch->Restore();
 			Pointers.GetAssistedAimTypePatch->Restore();
+			killed_peds.clear();
 		}
 	};
 
-	class AimbotAimForHead : BoolCommand
+	class AimbotAimForHead : public BoolCommand
 	{
 		using BoolCommand::BoolCommand;
 
@@ -35,7 +59,7 @@ namespace YimMenu::Features
 		}
 	};
 
-	class AimbotTargetDrivers : BoolCommand
+	class AimbotTargetDrivers : public BoolCommand
 	{
 		using BoolCommand::BoolCommand;
 


### PR DESCRIPTION
- Removed unnecessary running flag since OnTick() is called sequentially by the command system, ensuring thread safety without extra checks.
- Added killed_peds.clear() in both OnEnable() and OnDisable() to properly reset state when toggling the feature.
- Simplified the loop logic by eliminating the temporary set, reducing complexity and memory usage.
- Improved code clarity by consistently storing and using handle instead of multiple calls to ped.GetHandle().

Simplified and corrected version of Aimbot.cpp you might consider. 